### PR TITLE
moved tests out of omas

### DIFF
--- a/Omas/tests/test_musdocinfo.py
+++ b/Omas/tests/test_musdocinfo.py
@@ -2,7 +2,7 @@ import pytest
 
 import os
 from pymei import XmlImport
-from meiinfo import MusDocInfo
+from omas.meiinfo import MusDocInfo
 
 def test_DC_file():
 	meiDoc = XmlImport.documentFromFile(os.path.join("..", "data", "DC0101.mei"))


### PR DESCRIPTION
tests run if you do this, but they fail because of some paths to xml files that need to be adjusted after the move:

```
% pip install -e .
% py.test 
(ema)ubuntu@ip-10-39-110-115:~/ema/Omas$ py.test
============================= test session starts ==============================
platform linux2 -- Python 2.7.5 -- py-1.4.25 -- pytest-2.6.3
collected 2 items

tests/test_musdocinfo.py FF

=================================== FAILURES ===================================
_________________________________ test_DC_file _________________________________

    def test_DC_file():
>       meiDoc = XmlImport.documentFromFile(os.path.join("..", "data", "DC0101.mei"))
E    RuntimeError: The file ../data/DC0101.mei is malformed.

tests/test_musdocinfo.py:8: RuntimeError
_______________________________ test_MEI_samples _______________________________

    @pytest.mark.full
    def test_MEI_samples():
        path = os.path.join("..", "data", "MEISamples")
>       for mei in os.listdir(path):
            meiDoc = XmlImport.documentFromFile(os.path.join(path, mei))
E     OSError: [Errno 2] No such file or directory: '../data/MEISamples'

tests/test_musdocinfo.py:19: OSError
=========================== 2 failed in 0.45 seconds ==========================
```
