### PR TITLE
Separate API

### DIFF
--- a/Omas/omas/exceptions.py
+++ b/Omas/omas/exceptions.py
@@ -14,3 +14,6 @@ class UnknownMEIReadException(OmasException):
 
 class BadApiRequest(OmasException):
     pass
+
+class CannotAccessRemoteMEIException(OmasException):
+    pass

--- a/Omas/omas/exceptions.py
+++ b/Omas/omas/exceptions.py
@@ -1,0 +1,16 @@
+
+class OmasException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+class CannotReadMEIException(OmasException):
+    pass
+
+class CannotWriteMEIException(OmasException):
+    pass
+
+class UnknownMEIReadException(OmasException):
+    pass
+
+class BadApiRequest(OmasException):
+    pass

--- a/Omas/omas/meislicer.py
+++ b/Omas/omas/meislicer.py
@@ -1,9 +1,7 @@
 from meiinfo import MusDocInfo
-import api
+from omas.exceptions import BadApiRequest
 
 import re
-
-from pymei import XmlExport
 from pymeiext import getClosestStaffDefs
 
 
@@ -88,7 +86,7 @@ class MeiSlicer(object):
 
         for s_no in s_nos:
             if s_no not in sds:
-                raise api.BadApiRequest("Requested staves are not defined")
+                raise BadApiRequest("Requested staves are not defined")
 
         for i, m in enumerate(mm):
             data = {
@@ -163,7 +161,7 @@ class MeiSlicer(object):
         # According to the API, the beat selection must be a range,
         # even when only one beat is selected.
         if len(tstamps) != 2:
-            raise api.BadApiRequest("Invalid beat range")
+            raise BadApiRequest("Invalid beat range")
 
         tstamp_first = int(tstamps[0])
         tstamp_final = int(tstamps[1])
@@ -184,7 +182,7 @@ class MeiSlicer(object):
 
         # check that the requested beat actually fits in the meter
         if tstamp_first > int(meter_first["count"]) or tstamp_final > int(meter_final["count"]):
-            raise api.BadApiRequest("Request beat is out of measure bounds")
+            raise BadApiRequest("Request beat is out of measure bounds")
 
         # FIRST MEASURE
         staves = self.staves
@@ -375,9 +373,9 @@ class MeiSlicer(object):
             elif length == 2:
                 ranges += range(int(values[0]), int(values[1])+1)
             else:
-                raise api.BadApiRequest("Invalid range format")
+                raise BadApiRequest("Invalid range format")
 
             if not ranges:
-                raise api.BadApiRequest("Invalid range format")
+                raise BadApiRequest("Invalid range format")
 
         return ranges


### PR DESCRIPTION
This PR demonstrates a rework of the EMA API handler.

- All PyMEI functions are moved off the flask server api and into dedicated files (meiinfo.py and meislicer.py). 
- A new 'exceptions' file is provided, moving the `BadApiRequest` exception out of the flask API code so that it can be used across the whole project.
- A base class, `MEIServiceResource` is now present to handle common tasks shared by dedicated handlers.

A number of potential problems are addressed with this PR:

1. Circular imports are avoided by ensuring imports only go one way: api -> MEI handling libraries.
2. MEI Slice was writing the same file to the `tmp` directory, meaning that if two users were using the service at the same time there would be unexpected results. This is fixed by writing to an automatically-created temp dir using the `tempfile` library.
3. Better handling of various edge cases (MEI file malformed, file could not be read, etc.) with descriptive messages and exception catching.